### PR TITLE
Allow to access external drives

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,7 @@ apps:
       - mount-observe
       - cups
       - home
+      - removable-media
 
 parts:
   gnome-text-editor:


### PR DESCRIPTION
This patch allows gnome-text-editor to access external drives.

It partially fixes https://github.com/ubuntu/gnome-text-editor/issues/13

Fixes # (issue)

## Type of change

Please check only the options that are relevant.

- [ ] General Maintenance
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tried to open a file in an external drive using the current snapped version of gnome-text-editor, and it failed. I tried with this one and it succeeded. It also succeeded at saving data.

**Test Configuration**:

* OS (please include version):
* Any other relevant environment information:

## Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings

